### PR TITLE
Update default redirect URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This sample app lets you sign in with Spotify and swipe through your saved track
 
 ## Setup
 
-1. In `server/`, set `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, and `REDIRECT_URI` environment variables.
+1. In `server/`, set `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, and `REDIRECT_URI` environment variables. The recommended redirect URI is `http://127.0.0.1:8000/callback`.
 2. Run `npm install` in both `server/` and `client/` if not already installed.
 3. Build the client with `npm run build` in `client/`.
-4. Start the server with `npm start` in `server/`.
+4. Start the server with `npm start` in `server/` (it listens on port 8000).
 
-Then open `http://localhost:3001/login` to authenticate.
+Then open `http://127.0.0.1:8000/login` to authenticate.

--- a/server/index.js
+++ b/server/index.js
@@ -9,7 +9,8 @@ app.use(cors());
 
 const CLIENT_ID = process.env.SPOTIFY_CLIENT_ID || 'YOUR_CLIENT_ID';
 const CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET || 'YOUR_CLIENT_SECRET';
-const REDIRECT_URI = process.env.REDIRECT_URI || 'http://localhost:3001/callback';
+const REDIRECT_URI =
+  process.env.REDIRECT_URI || 'http://127.0.0.1:8000/callback';
 
 const spotifyApi = new SpotifyWebApi({
   clientId: CLIENT_ID,
@@ -61,6 +62,6 @@ app.get('/api/tracks', async (req, res) => {
 
 app.use(express.static('../client/dist'));
 
-app.listen(3001, () => {
-  console.log('Server listening on http://localhost:3001');
+app.listen(8000, () => {
+  console.log('Server listening on http://127.0.0.1:8000');
 });


### PR DESCRIPTION
## Summary
- use recommended redirect URI `http://127.0.0.1:8000/callback`
- run server on port 8000 and document setup instructions

## Testing
- `npm install --legacy-peer-deps` in client then `npm run build`
- `npm install` in server and `node index.js`

------
https://chatgpt.com/codex/tasks/task_e_6843959ae55083309b6c2e478654736f