### PR TITLE
Add env file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 client/dist/
 server/node_modules/
 client/node_modules/
+server/.env
+.env

--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@ This sample app lets you sign in with Spotify and swipe through your saved track
 
 ## Setup
 
-1. In `server/`, set `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, and `REDIRECT_URI` environment variables.
+1. In `server/`, create a `.env` file containing `SPOTIFY_CLIENT_ID`,
+   `SPOTIFY_CLIENT_SECRET`, and `REDIRECT_URI`. The recommended redirect URI is
+   `http://127.0.0.1:8000/callback`. These values are loaded from the
+   environment so your secrets stay private.
 2. Run `npm install` in both `server/` and `client/` if not already installed.
 3. Build the client with `npm run build` in `client/`.
-4. Start the server with `npm start` in `server/`.
+4. Start the server with `npm start` in `server/` (it listens on port 8000).
 
-Then open `http://localhost:3001/login` to authenticate.
+Then open `http://127.0.0.1:8000/login` to authenticate.

--- a/server/index.js
+++ b/server/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cookieParser = require('cookie-parser');
 const cors = require('cors');
 const SpotifyWebApi = require('spotify-web-api-node');
+require('dotenv').config();
 
 const app = express();
 app.use(cookieParser());
@@ -9,7 +10,8 @@ app.use(cors());
 
 const CLIENT_ID = process.env.SPOTIFY_CLIENT_ID || 'YOUR_CLIENT_ID';
 const CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET || 'YOUR_CLIENT_SECRET';
-const REDIRECT_URI = process.env.REDIRECT_URI || 'http://localhost:3001/callback';
+const REDIRECT_URI =
+  process.env.REDIRECT_URI || 'http://127.0.0.1:8000/callback';
 
 const spotifyApi = new SpotifyWebApi({
   clientId: CLIENT_ID,
@@ -61,6 +63,6 @@ app.get('/api/tracks', async (req, res) => {
 
 app.use(express.static('../client/dist'));
 
-app.listen(3001, () => {
-  console.log('Server listening on http://localhost:3001');
+app.listen(8000, () => {
+  console.log('Server listening on http://127.0.0.1:8000');
 });

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
+        "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "spotify-web-api-node": "^5.0.2"
       }
@@ -214,6 +215,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "spotify-web-api-node": "^5.0.2"
+    "spotify-web-api-node": "^5.0.2",
+    "dotenv": "^16.5.0"
   }
 }


### PR DESCRIPTION
## Summary
- ignore `.env` files and add `dotenv`
- update server to load environment variables from `.env`
- document secret setup using `.env`

## Testing
- `npm install --prefix server`
- `node server/index.js` (logs show server listening on port 8000)
- `npm install --legacy-peer-deps --prefix client`
- `npm run build --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_6843959ae55083309b6c2e478654736f