### PR TITLE
Document Node 18 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ This sample app lets you sign in with Spotify and swipe through your saved track
 
 ## Setup
 
-1. In `server/`, create a `.env` file containing `SPOTIFY_CLIENT_ID`,
+1. Use **Node.js 18** or later. Earlier versions lack the `crypto.getRandomValues`
+   API used by Vite during the build process.
+2. In `server/`, create a `.env` file containing `SPOTIFY_CLIENT_ID`,
    `SPOTIFY_CLIENT_SECRET`, and `REDIRECT_URI`. The recommended redirect URI is
    `http://127.0.0.1:8000/callback`. These values are loaded from the
    environment so your secrets stay private.
-2. Run `npm install` in both `server/` and `client/` if not already installed.
-3. Build the client with `npm run build` in `client/`.
-4. Start the server with `npm start` in `server/` (it listens on port 8000).
+3. Run `npm install` in both `server/` and `client/` if not already installed.
+4. Build the client with `npm run build` in `client/`.
+5. Start the server with `npm start` in `server/` (it listens on port 8000).
 
 Then open `http://127.0.0.1:8000/login` to authenticate.

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "engines": {
+    "node": ">=18"
+  },
   "type": "commonjs",
   "dependencies": {
     "react": "^18.3.1",

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "engines": {
+    "node": ">=18"
+  },
   "type": "commonjs",
   "dependencies": {
     "cookie-parser": "^1.4.7",


### PR DESCRIPTION
## Summary
- mention the minimum Node.js version in the README
- add an `engines` field to both package.json files so Node <18 fails early

## Testing
- `npm run build` in `client`
- `npm install` in `server`

------
https://chatgpt.com/codex/tasks/task_e_68439b9c019c83309abcfae32298e80f